### PR TITLE
Remove graphiql on production

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
           ip: req.ip,
           db
         },
-        graphiql: true
+        graphiql: process.env.NODE_ENV === 'development'
       }))
     )
     app.listen(4000)


### PR DESCRIPTION
Only launches GraphiQL if `NODE_ENV` equals `development`