### PR TITLE
Handle Memes on API Side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 MONGO_URL="mongodb://localhost"
 MEMEBOT_IP="127.0.0.1"
 NODE_ENV="development"
+MEME_DIR=./.memes

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+MONGO_URL="mongodb://localhost"
+MEMEBOT_IP="127.0.0.1"
+NODE_ENV="development"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.swp
 .env
 ecosystem.config.js
+.memes

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The API for interacting with the MemeBot Database
 
 5. Run `mongod` via the instructions from the previous step's install page
 
+5. Set the environment file up according to the example
+
 6. Seed the database by running `yarn seed`
 
 7. Start the graphql server by running `yarn develop`

--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
     "express-graphql": "^0.8.0",
+    "fluent-ffmpeg": "^2.1.2",
     "graphql": "^14.4.1",
-    "mongodb": "^3.2.7"
+    "mongodb": "^3.2.7",
+    "shortid": "^2.2.15",
+    "validator": "^12.2.0",
+    "ytdl-core": "^1.0.7"
   },
   "devDependencies": {
     "eslint": "^6.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,23 @@ for (let file of commandFiles) {
   root[name] = require(`./resolvers/${file}`)
 }
 
+// Set up / find existing local memes
+function initDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir)
+  }
+}
+initDir(path.resolve(process.env.MEME_DIR))
+
 // Databse and app
 MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
   .then(client => {
     const app = express()
     const db = client.db('memebot')
     app.set('trust proxy', true)
+
+    // GraphQL server
+    console.log('Running a GraphQL API server at localhost:4000/graphql')
     app.use(
       '/graphql',
       graphqlHTTP(req => ({
@@ -43,7 +54,12 @@ MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
         graphiql: process.env.NODE_ENV === 'development'
       }))
     )
+
+    // Static meme file server
+    const memes_path = path.resolve(process.env.MEME_DIR)
+    console.log('Serving memes from ' + memes_path)
+    app.use('/memes', express.static(memes_path))
+
     app.listen(4000)
-    console.log('Running a GraphQL API server at localhost:4000/graphql')
   })
   .catch(error => console.error(error))

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,16 @@ MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
           ip: req.ip,
           db
         },
-        graphiql: process.env.NODE_ENV === 'development'
+        graphiql: process.env.NODE_ENV === 'development',
+        customFormatErrorFn: err => {
+          console.log(err)
+          return {
+            message: err.message,
+            code: err.originalError && err.originalError.code,
+            locations: err.locations,
+            path: err.path
+          }
+        }
       }))
     )
 

--- a/src/meme-download/youtube.js
+++ b/src/meme-download/youtube.js
@@ -1,0 +1,62 @@
+const validator = require('validator')
+const ytdl = require('ytdl-core')
+const ffmpeg = require('fluent-ffmpeg')
+
+function validateUrl(url) {
+  const hostWhitelist = ['www.youtube.com', 'youtube.com', 'youtu.be']
+
+  if (
+    !validator.isURL(url, { host_whitelist: hostWhitelist }) &&
+    ytdl.validateURL(url)
+  ) {
+    throw new Error('The URL must be a youtube link')
+  }
+  return url
+}
+
+function validateTimes(data) {
+  const longPattern = /^-?(\d{1,2}:)?[0-5]?\d:[0-5]\d(.\d+)?$/
+  const shortPattern = /^-?\d+(.\d+)?$/
+
+  const invalidTimes = []
+
+  if (
+    !validator.matches(data.start, longPattern) &&
+    !validator.matches(data.start, shortPattern)
+  ) {
+    invalidTimes.push('start')
+  }
+
+  if (
+    !validator.matches(data.end, longPattern) &&
+    !validator.matches(data.end, shortPattern)
+  ) {
+    invalidTimes.push('end')
+  }
+
+  if (invalidTimes.length > 0) {
+    throw new Error(
+      `the ${invalidTimes.join(
+        ' and '
+      )} time must match \`[-][HH:]MM:SS[.m...]\` or \`[-]S+[.m...]\``
+    )
+  }
+}
+
+module.exports = function(data) {
+  validateUrl(data.url)
+  validateTimes(data)
+  const stream = ytdl(data.url, { filter: 'audio' })
+  return ffmpeg(stream)
+    .noVideo()
+    .seekOutput(data.start)
+    .format('mp3')
+    .outputOptions(['-write_xing 0', `-to ${data.end}`])
+    .on('end', () => {
+      console.log('Finished streaming ' + data.url)
+    })
+    .on('error', () => {
+      throw new Error('Something went wrong when downloading meme')
+    })
+    .stream()
+}

--- a/src/meme-upload/local-upload.js
+++ b/src/meme-upload/local-upload.js
@@ -2,15 +2,22 @@ const fs = require('fs')
 const path = require('path')
 const shortid = require('shortid')
 
-module.exports = function(stream) {
-  const file_id = shortid.generate() + '.mp3'
+module.exports = {
+  add: function(stream) {
+    const file_id = shortid.generate() + '.mp3'
 
-  const file_loc = path.join(process.env.MEME_DIR, file_id)
-  stream.pipe(fs.createWriteStream(file_loc))
+    const file_loc = path.join(process.env.MEME_DIR, file_id)
+    stream.pipe(fs.createWriteStream(file_loc))
 
-  console.log(file_id)
-  return new Promise(function(resolve, reject) {
-    stream.on('end', () => resolve(file_id))
-    stream.on('error', reject)
-  })
+    console.log(file_id)
+    return new Promise(function(resolve, reject) {
+      stream.on('end', () => resolve(file_id))
+      stream.on('error', reject)
+    })
+  },
+
+  delete: function(file_id) {
+    const file_loc = path.join(process.env.MEME_DIR, file_id)
+    return fs.promises.unlink(file_loc)
+  }
 }

--- a/src/meme-upload/local-upload.js
+++ b/src/meme-upload/local-upload.js
@@ -9,7 +9,6 @@ module.exports = {
     const file_loc = path.join(process.env.MEME_DIR, file_id)
     stream.pipe(fs.createWriteStream(file_loc))
 
-    console.log(file_id)
     return new Promise(function(resolve, reject) {
       stream.on('end', () => resolve(file_id))
       stream.on('error', reject)

--- a/src/meme-upload/local-upload.js
+++ b/src/meme-upload/local-upload.js
@@ -1,0 +1,16 @@
+const fs = require('fs')
+const path = require('path')
+const shortid = require('shortid')
+
+module.exports = function(stream) {
+  const file_id = shortid.generate() + '.mp3'
+
+  const file_loc = path.join(process.env.MEME_DIR, file_id)
+  stream.pipe(fs.createWriteStream(file_loc))
+
+  console.log(file_id)
+  return new Promise(function(resolve, reject) {
+    stream.on('end', () => resolve(file_id))
+    stream.on('error', reject)
+  })
+}

--- a/src/resolvers/createMeme.js
+++ b/src/resolvers/createMeme.js
@@ -6,10 +6,6 @@ module.exports = async function({ name, author, url, start, end }, { ip, db }) {
     throw new Error('You are not authenticated to mutation data!')
   }
 
-  if (start >= end) {
-    throw new Error('Meme starts before it ends')
-  }
-
   const memes = db.collection('memes')
   if (await memes.findOne({ commands: name })) {
     throw new Error('Duplicate Meme')

--- a/src/resolvers/createMeme.js
+++ b/src/resolvers/createMeme.js
@@ -1,17 +1,38 @@
-module.exports = async function({ name, author, url }, { ip, db }) {
+const yt_download = require('../meme-download/youtube')
+const local_upload = require('../meme-upload/local-upload')
+
+module.exports = async function({ name, author, url, start, end }, { ip, db }) {
   if (ip !== process.env.MEMEBOT_IP && process.env.NODE_ENV !== 'development') {
     throw new Error('You are not authenticated to mutation data!')
   }
+
+  if (start >= end) {
+    throw new Error('Meme starts before it ends')
+  }
+
   const memes = db.collection('memes')
-  return await memes
-    .insertOne({
-      name,
-      author,
-      url,
-      commands: [name],
-      tags: [],
-      volume: 1.0,
-      createdAt: new Date()
+  if (await memes.findOne({ commands: name })) {
+    throw new Error('Duplicate Meme')
+  }
+
+  const meme = {
+    url: url,
+    start: start ? start : 0,
+    end: end ? end : 0
+  }
+
+  return local_upload(yt_download(meme))
+    .then(function(file_name) {
+      const new_url = '/memes/' + file_name
+      return memes.insertOne({
+        name,
+        author,
+        url: new_url,
+        commands: [name],
+        tags: [],
+        volume: 1.0,
+        createdAt: new Date()
+      })
     })
     .then(result => result.ops[0])
 }

--- a/src/resolvers/createMeme.js
+++ b/src/resolvers/createMeme.js
@@ -1,5 +1,5 @@
 const yt_download = require('../meme-download/youtube')
-const local_upload = require('../meme-upload/local-upload')
+const local_upload = require('../meme-upload/local-upload').add
 
 module.exports = async function({ name, author, url, start, end }, { ip, db }) {
   if (ip !== process.env.MEMEBOT_IP && process.env.NODE_ENV !== 'development') {

--- a/src/resolvers/deleteMeme.js
+++ b/src/resolvers/deleteMeme.js
@@ -1,7 +1,11 @@
+const local_delete = require('../meme-upload/local-upload').delete
+
 module.exports = async function({ name }, { ip, db }) {
   if (ip !== process.env.MEMEBOT_IP && process.env.NODE_ENV !== 'development') {
     throw new Error('You are not authenticated to mutation data!')
   }
   const memes = db.collection('memes')
-  return await memes.findOneAndDelete({ name }).then(result => result.value)
+  const meme = (await memes.findOneAndDelete({ name })).value
+  await local_delete(meme.url.replace(/^\/memes.*\//, ''))
+  return meme
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3,7 +3,7 @@ scalar DateTime
 type Query {
   info: String!
   memes: [Meme!]!
-  meme(command: String!): Meme!
+  meme(command: String!): Meme
   commands: [String!]!
   tags: [String!]!
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -9,7 +9,13 @@ type Query {
 }
 
 type Mutation {
-  createMeme(name: String!, author: UserInput!, url: String!): Meme!
+  createMeme(
+    name: String!
+    author: UserInput!
+    url: String!
+    start: String!
+    end: String!
+  ): Meme!
   deleteMeme(name: String!): Meme
   addAliasToMeme(name: String!, alias: String!): Meme
   removeAliasFromMeme(name: String!, alias: String!): Meme

--- a/src/seed.js
+++ b/src/seed.js
@@ -4,24 +4,7 @@ require('dotenv').config()
 MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
   .then(async client => {
     const db = client.db('memebot')
-    const memes = db.collection('memes')
-    await memes.insertOne({ x: 'test' }) //Ensure databse is created
-    await memes.drop()
-    await memes.createIndex({ name: 1 }, { unique: true })
-    await memes.createIndex({ commands: 1 }, { unique: true })
-    await memes.createIndex({ tags: 1 })
-    await memes.insertOne({
-      name: 'Caveman',
-      author: {
-        id: '28937918273',
-        name: 'Arjun'
-      },
-      url: 'https://memebot.solutions/memes/caveman.mp3',
-      commands: ['Caveman'],
-      tags: ['shaggy'],
-      volume: 1.0,
-      createdAt: new Date()
-    })
+    db.collection('memes')
     client.close()
   })
   .catch(error => console.error(error))

--- a/src/seed.js
+++ b/src/seed.js
@@ -7,7 +7,18 @@ require('dotenv').config()
 MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
   .then(async client => {
     const db = client.db('memebot')
-    const memes = db.collection('memes')
+    await db.dropCollection('memes')
+    const memes = await db.createCollection('memes', {
+      collation: { locale: 'en_US', strength: 2 }
+    })
+    memes.createIndex(
+      { name: 1 },
+      { collation: { locale: 'en_US', strength: 2 } }
+    )
+    memes.createIndex(
+      { commands: 1 },
+      { collation: { locale: 'en_US', strength: 2 } }
+    )
 
     if (process.argv[2] === 'og' && process.argv.length === 5) {
       const meme_dir = process.argv[3]
@@ -16,8 +27,6 @@ MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
       const meme_files = fs
         .readdirSync(meme_dir)
         .filter(file => file.endsWith('.json'))
-
-      console.log(meme_files)
 
       for (const meme_file of meme_files) {
         const old_meme = JSON.parse(

--- a/src/seed.js
+++ b/src/seed.js
@@ -1,10 +1,46 @@
+const fs = require('fs')
+const path = require('path')
+const local_upload = require('./meme-upload/local-upload').add
 const MongoClient = require('mongodb').MongoClient
 require('dotenv').config()
 
 MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true })
   .then(async client => {
     const db = client.db('memebot')
-    db.collection('memes')
+    const memes = db.collection('memes')
+
+    if (process.argv[2] === 'og' && process.argv.length === 5) {
+      const meme_dir = process.argv[3]
+      const audio_dir = process.argv[4]
+
+      const meme_files = fs
+        .readdirSync(meme_dir)
+        .filter(file => file.endsWith('.json'))
+
+      console.log(meme_files)
+
+      for (const meme_file of meme_files) {
+        const old_meme = JSON.parse(
+          fs.readFileSync(path.join(meme_dir, meme_file))
+        )
+        const old_audio = path.join(audio_dir, old_meme.file)
+
+        const file_name = await local_upload(fs.createReadStream(old_audio))
+
+        memes.insertOne({
+          name: old_meme.name,
+          author: {
+            id: old_meme.authorID,
+            name: old_meme.author
+          },
+          url: '/memes/' + file_name,
+          commands: old_meme.commands,
+          tags: old_meme.tags,
+          volume: old_meme.volume != null ? old_meme.volume : 1,
+          createdAt: old_meme.dateAdded
+        })
+      }
+    }
     client.close()
   })
   .catch(error => console.error(error))

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,11 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async@>=0.2.9:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.1.1.tgz#dd3542db03de837979c9ebbca64ca01b06dc98df"
+  integrity sha512-X5Dj8hK1pJNC2Wzo2Rcp9FBVdJMGRR/S7V+lH46s8GVFhtbo5O4Le5GECCF/8PISVdkUA6mMPvgz7qTTD1rf1g==
+
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -881,6 +886,14 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+fluent-ffmpeg@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz#c952de2240f812ebda0aa8006d7776ee2acf7d74"
+  integrity sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=
+  dependencies:
+    async ">=0.2.9"
+    which "^1.1.1"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1065,6 +1078,11 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+html-entities@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+  integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
 http-errors@1.7.2:
   version "1.7.2"
@@ -1456,6 +1474,14 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+m3u8stream@^0.6.3:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/m3u8stream/-/m3u8stream-0.6.4.tgz#c2cdeb8401d340cc476029e433177caa089a26e9"
+  integrity sha512-9WLF1VAtbVij03HWJKbVZ8L0orsoZiP53UljR5EwaDrozQFMsTGRDPe3PbzWV73He8a+j5H/hWZNoI2VkUSsiw==
+  dependencies:
+    miniget "^1.6.1"
+    sax "^1.2.4"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -1535,6 +1561,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+miniget@^1.6.0, miniget@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/miniget/-/miniget-1.6.1.tgz#f1ae08a34e06a2b1c3ace568384ea0def2fe5813"
+  integrity sha512-I5oBwZmcaOuJrjQn7lpS29HM+aAZDbzKbX5ouxVyhFYdg6fA6YKOTwOCgzZQwlHuMek3FlCxz6eNrd4pOXbwOA==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -1626,6 +1657,11 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nanoid@^2.1.0:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -2147,7 +2183,7 @@ saslprep@^1.0.0:
   dependencies:
     sparse-bitfield "^3.0.3"
 
-sax@^1.2.4:
+sax@^1.1.3, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -2229,6 +2265,13 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shortid@^2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -2614,12 +2657,17 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
+validator@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-12.2.0.tgz#660d47e96267033fd070096c3b1a6f2db4380a0a"
+  integrity sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-which@^1.2.9:
+which@^1.1.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -2680,3 +2728,13 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+ytdl-core@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-1.0.7.tgz#2cda813e6429eb35aee349656b8f5693314b6992"
+  integrity sha512-gECPN5g5JnSy8hIq11xHIGe1T/Xzy0mWxQin3zhlJ3nG/YjPcEVEejrdd2XmA4Vv2Zw3+b1ZyDjmt37XfZri6A==
+  dependencies:
+    html-entities "^1.1.3"
+    m3u8stream "^0.6.3"
+    miniget "^1.6.0"
+    sax "^1.1.3"


### PR DESCRIPTION
Handle memes on the API side of the memebot. 

Currently only allow for local storage of memes, but there's a path forward for hosting memes on alternate services.  MEME_DIR environment variable is needed to specify the directory for the locally stored memes.

We now serve HTTP get requests to /memes to the MEME_DIR directory.

Add meme now additionally takes in a start and end time and then downloads the meme from the service and stores it locally. A non-related short name is used for the filenames as of the moment. That can be changed to store as the name of the meme instead, but I liked it better at the moment. 

